### PR TITLE
exception handling for get intelligence ioc DDS-137

### DIFF
--- a/ds_intelligence_incidents_connector.py
+++ b/ds_intelligence_incidents_connector.py
@@ -124,6 +124,9 @@ class DSIntelligenceIncidentsConnector(object):
                     action_result.add_data(intelligence_incident_ioc.payload)
 
             action_result.set_status(phantom.APP_SUCCESS, DS_GET_INTELLIGENCE_INCIDENT_SUCCESS)
+        else:
+            action_result.set_status(phantom.APP_SUCCESS, "Returned empty response from Searchlight")
+
         return action_result.get_status()
 
     def get_intelligence_incident(self, param):


### PR DESCRIPTION
The request was successful but getting empty responses were failing the action. Now action has status as success and tells no data returned instead of failing altogether. 